### PR TITLE
added MeshCollider to RoadMeshCreator.cs V2

### DIFF
--- a/PathCreator/Examples/Scripts/RoadMeshCreator.cs
+++ b/PathCreator/Examples/Scripts/RoadMeshCreator.cs
@@ -11,6 +11,7 @@ namespace PathCreation.Examples
         [Range(0, .5f)]
         public float thickness = .15f;
         public bool flattenSurface;
+        public bool meshCollider;
 
         [Header("Material settings")]
         public Material roadMaterial;
@@ -20,16 +21,19 @@ namespace PathCreation.Examples
         MeshFilter meshFilter;
         MeshRenderer meshRenderer;
 
+        string meshHolderName = "Mesh Holder";
+
         protected override void PathUpdated()
         {
             if (pathCreator != null)
             {
                 AssignMeshComponents();
                 AssignMaterials();
-                meshFilter.mesh = CreateRoadMesh();;
+                meshFilter.mesh = CreateRoadMesh();
+                UpdateMeshCollider(meshCollider);
             }
         }
-
+        
 
         Mesh CreateRoadMesh()
         {
@@ -132,7 +136,6 @@ namespace PathCreation.Examples
         void AssignMeshComponents()
         {
             // Find/creator mesh holder object in children
-            string meshHolderName = "Mesh Holder";
             Transform meshHolder = transform.Find(meshHolderName);
             if (meshHolder == null) {
                 meshHolder = new GameObject(meshHolderName).transform;
@@ -165,6 +168,37 @@ namespace PathCreation.Examples
                 meshRenderer.sharedMaterials[0].mainTextureScale = new Vector3(1, textureTiling);
             }
         }
+
+        //update meshcolider if enabled
+        void UpdateMeshCollider(bool meshColliderEnable)
+        {
+            GameObject meshHolder = transform.Find(meshHolderName).gameObject;
+            if (meshHolder != null)
+            {
+                MeshCollider meshCol = meshHolder.GetComponent<MeshCollider>();
+                if (meshCol != null)
+                {
+                    bool convex = meshCol.convex;
+                    bool isTrigger = meshCol.isTrigger;
+                    MeshColliderCookingOptions cookingOptions = meshCol.cookingOptions;
+                    PhysicMaterial material = meshCol.material;
+                    DestroyImmediate(meshCol);
+                    if (meshColliderEnable)
+                    {
+                        meshCol = meshHolder.AddComponent<MeshCollider>();
+                        meshCol.convex = convex;
+                        meshCol.isTrigger = isTrigger;
+                        meshCol.cookingOptions = cookingOptions;
+                        meshCol.material = material;
+                    }
+                }
+                else if (meshColliderEnable)
+                {
+                    meshHolder.AddComponent<MeshCollider>();
+                }
+            }
+        }
+
 
     }
 }

--- a/PathCreator/Examples/Scripts/RoadMeshCreator.cs
+++ b/PathCreator/Examples/Scripts/RoadMeshCreator.cs
@@ -21,7 +21,7 @@ namespace PathCreation.Examples
         MeshFilter meshFilter;
         MeshRenderer meshRenderer;
 
-        string meshHolderName = "Mesh Holder";
+        Transform meshHolder;
 
         protected override void PathUpdated()
         {
@@ -136,7 +136,8 @@ namespace PathCreation.Examples
         void AssignMeshComponents()
         {
             // Find/creator mesh holder object in children
-            Transform meshHolder = transform.Find(meshHolderName);
+            string meshHolderName = "Mesh Holder";
+            meshHolder = transform.Find(meshHolderName);
             if (meshHolder == null) {
                 meshHolder = new GameObject(meshHolderName).transform;
                 meshHolder.transform.parent = transform;
@@ -172,29 +173,23 @@ namespace PathCreation.Examples
         //update meshcolider if enabled
         void UpdateMeshCollider(bool meshColliderEnable)
         {
-            GameObject meshHolder = transform.Find(meshHolderName).gameObject;
             if (meshHolder != null)
             {
                 MeshCollider meshCol = meshHolder.GetComponent<MeshCollider>();
                 if (meshCol != null)
                 {
-                    bool convex = meshCol.convex;
-                    bool isTrigger = meshCol.isTrigger;
-                    MeshColliderCookingOptions cookingOptions = meshCol.cookingOptions;
-                    PhysicMaterial material = meshCol.material;
-                    DestroyImmediate(meshCol);
                     if (meshColliderEnable)
                     {
-                        meshCol = meshHolder.AddComponent<MeshCollider>();
-                        meshCol.convex = convex;
-                        meshCol.isTrigger = isTrigger;
-                        meshCol.cookingOptions = cookingOptions;
-                        meshCol.material = material;
+                        meshCol.sharedMesh = meshHolder.GetComponent<MeshFilter>().sharedMesh;
                     }
+                    else
+                    {
+                        DestroyImmediate(meshCol);
+                    }                
                 }
                 else if (meshColliderEnable)
                 {
-                    meshHolder.AddComponent<MeshCollider>();
+                    meshHolder.gameObject.AddComponent<MeshCollider>();
                 }
             }
         }


### PR DESCRIPTION
improved Version of https://github.com/SebLague/Path-Creator/pull/19

Thanks for your feedback.
I did the following changes in my code:
- I changed my code to reassign MeshCollider.sharedMesh instead if deleting the collider
- My additions do not add another Transform.Find
- That the users has to match the name string of the mesh holder is the problem of the original version. I don’t think that this is a real issue since this object is auto-generated.