### PR TITLE
Optimizations to CubicBezierUtility methods

### DIFF
--- a/PathCreator/Core/Runtime/Utility/CubicBezierUtility.cs
+++ b/PathCreator/Core/Runtime/Utility/CubicBezierUtility.cs
@@ -53,8 +53,17 @@ namespace PathCreation.Utility
         /// This is the vector tangent to the curve at that point
         public static Vector3 EvaluateCurveDerivative(Vector3 a1, Vector3 c1, Vector3 c2, Vector3 a2, float t)
         {
-            t = Mathf.Clamp01(t);
-            return 3 * (1 - t) * (1 - t) * (c1 - a1) + 6 * (1 - t) * t * (c2 - c1) + 3 * t * t * (a2 - c2);
+            t = t < 0f ? 0f : t > 1f ? 1f : t;
+
+            float s1 = 3 * (1 - t) * (1 - t);
+            float s2 = 6 * (1 - t) * t;
+            float s3 = 3 * t * t;
+
+            float x = s1 * (c1.x - a1.x) + s2 * (c2.x - c1.x) + s3 * (a2.x - c2.x);
+            float y = s1 * (c1.y - a1.y) + s2 * (c2.y - c1.y) + s3 * (a2.y - c2.y);
+            float z = s1 * (c1.z - a1.z) + s2 * (c2.z - c1.z) + s3 * (a2.z - c2.z);
+
+            return new Vector3( x, y, z );
         }
 
         /// Returns the second derivative of the curve at time 't'
@@ -71,8 +80,16 @@ namespace PathCreation.Utility
         ///Returns the second derivative of the curve at time 't'
         public static Vector3 EvaluateCurveSecondDerivative(Vector3 a1, Vector3 c1, Vector3 c2, Vector3 a2, float t)
         {
-            t = Mathf.Clamp01(t);
-            return 6 * (1 - t) * (c2 - 2 * c1 + a1) + 6 * t * (a2 - 2 * c2 + c1);
+            t = t < 0f ? 0f : t > 1f ? 1f : t;
+
+            float s1 = 6 * (1 - t);
+            float s2 = 6 * t;
+
+            float x = s1 * (c2.x - 2 * c1.x + a1.x) + s2 * (a2.x - 2 * c2.x + c1.x);
+            float y = s1 * (c2.y - 2 * c1.y + a1.y) + s2 * (a2.y - 2 * c2.y + c1.y);
+            float z = s1 * (c2.z - 2 * c1.z + a1.z) + s2 * (a2.z - 2 * c2.z + c1.z);
+
+            return new Vector3( x, y, z );
         }
 
 

--- a/PathCreator/Core/Runtime/Utility/CubicBezierUtility.cs
+++ b/PathCreator/Core/Runtime/Utility/CubicBezierUtility.cs
@@ -12,7 +12,7 @@ namespace PathCreation.Utility
         /// Returns point at time 't' (between 0 and 1) along bezier curve defined by 4 points (anchor_1, control_1, control_2, anchor_2)
         public static Vector3 EvaluateCurve(Vector3[] points, float t)
         {
-            Debug.Assert(points.Length == 4, "Incorrect number of points supplied to cubic bezier function. Expected 4, but received " + points.Length);
+            Debug.AssertFormat(points.Length == 4, "Incorrect number of points supplied to cubic bezier function. Expected 4, but received {0}", points.Length);
             if (points.Length >= 4)
             {
                 return EvaluateCurve(points[0], points[1], points[2], points[3], t);
@@ -31,7 +31,7 @@ namespace PathCreation.Utility
         /// This is the vector tangent to the curve at that point
         public static Vector3 EvaluateCurveDerivative(Vector3[] points, float t)
         {
-            Debug.Assert(points.Length == 4, "Incorrect number of points supplied to cubic bezier function. Expected 4, but received " + points.Length);
+            Debug.AssertFormat(points.Length == 4, "Incorrect number of points supplied to cubic bezier function. Expected 4, but received {0}", points.Length);
             if (points.Length >= 4)
             {
                 return EvaluateCurveDerivative(points[0], points[1], points[2], points[3], t);
@@ -50,7 +50,7 @@ namespace PathCreation.Utility
         /// Returns the second derivative of the curve at time 't'
         public static Vector3 EvaluateCurveSecondDerivative(Vector3[] points, float t)
         {
-            Debug.Assert(points.Length == 4, "Incorrect number of points supplied to cubic bezier function. Expected 4, but received " + points.Length);
+            Debug.AssertFormat(points.Length == 4, "Incorrect number of points supplied to cubic bezier function. Expected 4, but received {0}", points.Length);
             if (points.Length >= 4)
             {
                 return EvaluateCurveSecondDerivative(points[0], points[1], points[2], points[3], t);
@@ -69,7 +69,7 @@ namespace PathCreation.Utility
         /// Calculates the normal vector (vector perpendicular to the curve) at specified time
         public static Vector3 Normal(Vector3[] points, float t)
         {
-            Debug.Assert(points.Length == 4, "Incorrect number of points supplied to cubic bezier function. Expected 4, but received " + points.Length);
+            Debug.AssertFormat(points.Length == 4, "Incorrect number of points supplied to cubic bezier function. Expected 4, but received {0}", points.Length);
             if (points.Length >= 4)
             {
                 return Normal(points[0], points[1], points[2], points[3], t);
@@ -88,7 +88,7 @@ namespace PathCreation.Utility
 
         public static Bounds CalculateBounds(Vector3[] points)
         {
-            Debug.Assert(points.Length == 4, "Incorrect number of points supplied to cubic bezier function. Expected 4, but received " + points.Length);
+            Debug.AssertFormat(points.Length == 4, "Incorrect number of points supplied to cubic bezier function. Expected 4, but received {0}", points.Length);
             MinMax3D minMax = new MinMax3D();
             if (points.Length >= 4)
             {

--- a/PathCreator/Core/Runtime/Utility/CubicBezierUtility.cs
+++ b/PathCreator/Core/Runtime/Utility/CubicBezierUtility.cs
@@ -23,8 +23,18 @@ namespace PathCreation.Utility
         /// Returns point at time 't' (between 0 and 1)  along bezier curve defined by 4 points (anchor_1, control_1, control_2, anchor_2)
         public static Vector3 EvaluateCurve(Vector3 a1, Vector3 c1, Vector3 c2, Vector3 a2, float t)
         {
-            t = Mathf.Clamp01(t);
-            return (1 - t) * (1 - t) * (1 - t) * a1 + 3 * (1 - t) * (1 - t) * t * c1 + 3 * (1 - t) * t * t * c2 + t * t * t * a2;
+            t = t < 0f ? 0f : t > 1f ? 1f : t;
+
+            float s1 = (1 - t) * (1 - t) * (1 - t);
+            float s2 = 3 * (1 - t) * (1 - t) * t;
+            float s3 = 3 * (1 - t) * t * t;
+            float s4 = t * t * t;
+
+            float x = s1 * a1.x + s2 * c1.x + s3 * c2.x + s4 * a2.x;
+            float y = s1 * a1.y + s2 * c1.y + s3 * c2.y + s4 * a2.y;
+            float z = s1 * a1.z + s2 * c1.z + s3 * c2.z + s4 * a2.z;
+
+            return new Vector3( x, y, z );
         }
 
         /// Returns a vector tangent to the point at time 't'


### PR DESCRIPTION
While using Path-Creator on a project that generates bezier curves from screenspace coordinates, I noticed some serious slowdown on relatively simple paths (6 segments) due to the distance between points. At the scale of hundreds of thousands of divisions, a few easy optimizations to some of the CubicBezierUtility functions popped out.

1. The Debug.Assert() calls include a string concatenation, which will happen regardless of whether or not the assert fails. I was seeing 70MB+ a frame. By changing these to Debug.AssetFormat() the memory allocated drops considerably but it was still in the ~7MB range. I wanted to preserve the original functionality with this pull request, but if you're open to eliminating those allocations entirely I would recommend removing the length of the points array from the assert log and just informing the user that the number of points was invalid.

2. The Evaluate*() methods perform a lot of vector math. The temporary vectors generated from multiplication and addition live on the stack, but there's still a substantial cost to constructing them. I broke the calculations down into scalar math as well as inlined the Mathf.Clamp() call and saw a substantial speedup.