### PR TITLE
Add raycast check to GetMouseWorldPosition

### DIFF
--- a/Path Creator Project/Assets/PathCreator/Core/Editor/Helper/MouseUtility.cs
+++ b/Path Creator Project/Assets/PathCreator/Core/Editor/Helper/MouseUtility.cs
@@ -7,31 +7,33 @@ namespace PathCreationEditor
     public static class MouseUtility
     {
         /// <summary>
-		/// Determines mouse position in world. If PathSpace is xy/xz, the position will be locked to that plane.
-		/// If PathSpace is xyz, then depthFor3DSpace will be used as distance from scene camera.
-		/// </summary>
+        /// Determines mouse position in world. If PathSpace is xy/xz, the position will be locked to that plane.
+        /// If PathSpace is xyz, will attempt to raycast to a reasonably close object, or return the position
+        /// at depthFor3DSpace distance from the current view
+        /// </summary>
         public static Vector3 GetMouseWorldPosition(PathSpace space, float depthFor3DSpace = 10)
         {
-            Ray mouseRay = HandleUtility.GUIPointToWorldRay(Event.current.mousePosition);
-            Vector3 worldMouse = mouseRay.GetPoint(depthFor3DSpace);
+            var mouseRay = HandleUtility.GUIPointToWorldRay(Event.current.mousePosition);
+            var worldMouse = Physics.Raycast(mouseRay, out var hitInfo, depthFor3DSpace * 2f) ? 
+                hitInfo.point : mouseRay.GetPoint(depthFor3DSpace);
 
             // Mouse can only move on XY plane
             if (space == PathSpace.xy)
             {
-                float zDir = mouseRay.direction.z;
+                var zDir = mouseRay.direction.z;
                 if (zDir != 0)
                 {
-                    float dstToXYPlane = Mathf.Abs(mouseRay.origin.z / zDir);
+                    var dstToXYPlane = Mathf.Abs(mouseRay.origin.z / zDir);
                     worldMouse = mouseRay.GetPoint(dstToXYPlane);
                 }
             }
             // Mouse can only move on XZ plane 
             else if (space == PathSpace.xz)
             {
-                float yDir = mouseRay.direction.y;
+                var yDir = mouseRay.direction.y;
                 if (yDir != 0)
                 {
-                    float dstToXZPlane = Mathf.Abs(mouseRay.origin.y / yDir);
+                    var dstToXZPlane = Mathf.Abs(mouseRay.origin.y / yDir);
                     worldMouse = mouseRay.GetPoint(dstToXZPlane);
                 }
             }


### PR DESCRIPTION
When building a path on top of a given scene, may intuitively expect to
click on points in the scene geometry to add path segments. However, the
path creator always creates points a pre-specified distance from the
editor camera.

Added a raycast check that looks for potential geometry the user may be
clicking on. If there is geometry close to the pre-specified distance, a
point will be generated at the ray intersection. Otherwise, we fall back
to the original behavior. (Some type declaration changes to get my IDE to
stop yelling at me)

Tested manually in editor.