### PR TITLE
VertexPath.CalculateClosestPointOnPathData optimization

### DIFF
--- a/Path Creator Project/Assets/PathCreator/Examples/Scenes/GetClosestPointOnPath Test.unity
+++ b/Path Creator Project/Assets/PathCreator/Examples/Scenes/GetClosestPointOnPath Test.unity
@@ -144,17 +144,47 @@ MonoBehaviour:
     _bezierPath:
       points:
       - {x: -4.350084, y: -0.6192361, z: 0.36958665}
-      - {x: -4.3119984, y: -0.27224493, z: 2.7627096}
-      - {x: -2.500093, y: 1.7315861, z: 2.2386506}
+      - {x: -4.3476486, y: -0.597047, z: 0.52262044}
+      - {x: -2.7572303, y: -0.70872635, z: 1.6174023}
+      - {x: -2.3782218, y: -0.38763738, z: 1.8379713}
+      - {x: -1.9992132, y: -0.06654839, z: 2.0585403}
+      - {x: -2.4454098, y: 0.8219146, z: 1.9317083}
+      - {x: -2.0614424, y: 1.2668917, z: 1.9732294}
+      - {x: -1.677475, y: 1.7118688, z: 2.0147505}
+      - {x: -0.46440378, y: 1.7154288, z: 2.2258382}
       - {x: 0.14839771, y: 1.7105651, z: 2.2219813}
-      - {x: 2.7968912, y: 1.6895441, z: 2.205312}
-      - {x: 4.16408, y: -0.44785511, z: 2.1293974}
+      - {x: 0.76119924, y: 1.7057014, z: 2.2181244}
+      - {x: 4.2510085, y: -0.53037375, z: 1.282062}
       - {x: 4.3446193, y: -0.6192361, z: 0.36958665}
-      - {x: 4.5251584, y: -0.7906171, z: -1.390224}
-      - {x: 3.2920637, y: 0.7694727, z: -2.9261537}
-      - {x: 0.77272415, y: 0.83640313, z: -3.0503848}
-      - {x: -1.7466154, y: 0.90333354, z: -3.1746159}
-      - {x: -4.3881693, y: -0.9662273, z: -2.0235362}
+      - {x: 4.43823, y: -0.7080985, z: -0.54288876}
+      - {x: 6.1194963, y: 0.44442305, z: -2.4886756}
+      - {x: 3.7941601, y: -0.07067474, z: -2.6234398}
+      - {x: 1.4688243, y: -0.5857725, z: -2.758204}
+      - {x: 5.180417, y: 0.88676715, z: -3.9433024}
+      - {x: 4.939216, y: 1.0569758, z: -4.3701224}
+      - {x: 4.698015, y: 1.2271845, z: -4.7969427}
+      - {x: 2.5704806, y: 0.8330983, z: -4.9625225}
+      - {x: 2.446082, y: 0.83640313, z: -4.9686565}
+      - {x: 2.3216836, y: 0.839708, z: -4.9747906}
+      - {x: 0.31069377, y: 0.7397387, z: -2.727452}
+      - {x: -0.3484243, y: 0.69917965, z: -2.494286}
+      - {x: -1.0075424, y: 0.6586206, z: -2.26112}
+      - {x: -1.4713835, y: -1.2655108, z: -2.326689}
+      - {x: -2.1617332, y: -1.2623534, z: -2.510853}
+      - {x: -2.8520832, y: -1.259196, z: -2.695017}
+      - {x: -3.6936672, y: 0.7034443, z: -3.0868487}
+      - {x: -3.5478704, y: 0.910876, z: -3.260935}
+      - {x: -3.4020736, y: 1.1183076, z: -3.4350214}
+      - {x: -4.3403153, y: 1.11183, z: -3.5472014}
+      - {x: -4.5300093, y: 1.5598526, z: -4.0236}
+      - {x: -4.719703, y: 2.0078752, z: -4.4999995}
+      - {x: -4.878911, y: 0.7921399, z: -2.921095}
+      - {x: -4.9720774, y: 0.74950266, z: -2.794322}
+      - {x: -5.0652437, y: 0.70686543, z: -2.6675491}
+      - {x: -6.667046, y: 0.38763303, z: -1.8212851}
+      - {x: -6.4901414, y: 0.058772564, z: -1.1090026}
+      - {x: -6.3132367, y: -0.2700879, z: -0.39672005}
+      - {x: -4.352519, y: -0.64142525, z: 0.21655288}
       isClosed: 1
       space: 0
       controlMode: 1
@@ -164,6 +194,16 @@ MonoBehaviour:
         m_Center: {x: 0.005727291, y: 0.5250117, z: -0.39030027}
         m_Extent: {x: 4.3562183, y: 1.1872373, z: 2.6691647}
       perAnchorNormalsAngle:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
       - 0
       - 0
       - 0
@@ -204,58 +244,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1266884696
-Prefab:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 4125965570099986, guid: 761d600d1e80341ac97f3228771ce637, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4125965570099986, guid: 761d600d1e80341ac97f3228771ce637, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4125965570099986, guid: 761d600d1e80341ac97f3228771ce637, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4125965570099986, guid: 761d600d1e80341ac97f3228771ce637, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4125965570099986, guid: 761d600d1e80341ac97f3228771ce637, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4125965570099986, guid: 761d600d1e80341ac97f3228771ce637, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4125965570099986, guid: 761d600d1e80341ac97f3228771ce637, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4125965570099986, guid: 761d600d1e80341ac97f3228771ce637, type: 2}
-      propertyPath: m_RootOrder
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 114548013775708692, guid: 761d600d1e80341ac97f3228771ce637,
-        type: 2}
-      propertyPath: pathCreator
-      value: 
-      objectReference: {fileID: 184727958}
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 761d600d1e80341ac97f3228771ce637, type: 2}
-  m_IsPrefabParent: 0
---- !u!4 &1266884697 stripped
-Transform:
-  m_PrefabParentObject: {fileID: 4125965570099986, guid: 761d600d1e80341ac97f3228771ce637,
-    type: 2}
-  m_PrefabInternal: {fileID: 1266884696}
 --- !u!1 &1308570505
 GameObject:
   m_ObjectHideFlags: 0
@@ -329,6 +317,150 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1312361968
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1312361971}
+  - component: {fileID: 1312361970}
+  - component: {fileID: 1312361969}
+  m_Layer: 0
+  m_Name: New Position Result
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!23 &1312361969
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1312361968}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 9ca80467a033e954a8b9ad8601d6f4c7, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1312361970
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1312361968}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1312361971
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1312361968}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.1773397, y: -2.0806398, z: -0.9905968}
+  m_LocalScale: {x: 0.15, y: 2, z: 0.15}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1336900834
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1336900837}
+  - component: {fileID: 1336900836}
+  - component: {fileID: 1336900835}
+  m_Layer: 0
+  m_Name: Old Position Result
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!23 &1336900835
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1336900834}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 01763a1c279a5cd4d8f897f6b6cdbae5, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1336900836
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1336900834}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1336900837
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1336900834}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.1773397, y: -2.0806398, z: -0.9905968}
+  m_LocalScale: {x: 0.2, y: 1, z: 0.2}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1414926773
 GameObject:
   m_ObjectHideFlags: 0
@@ -357,7 +489,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   pathCreator: {fileID: 184727958}
-  objectOnPath: {fileID: 1266884697}
+  inputPositionObject: {fileID: 1625705262}
+  oldMethodObject: {fileID: 1336900837}
+  newMethodObject: {fileID: 1312361971}
 --- !u!4 &1414926775
 Transform:
   m_ObjectHideFlags: 0
@@ -369,7 +503,79 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1625705259
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1625705262}
+  - component: {fileID: 1625705261}
+  - component: {fileID: 1625705260}
+  m_Layer: 0
+  m_Name: Input Position
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!23 &1625705260
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1625705259}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 5c270a73328a99e439fec44a0cf3a17d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1625705261
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1625705259}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1625705262
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1625705259}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 2.81, y: -2.0806398, z: -0.78}
+  m_LocalScale: {x: 0.25, y: 0.25, z: 0.25}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1844901808
 GameObject:

--- a/Path Creator Project/Assets/PathCreator/Examples/Scenes/GetClosestPointOnPath Test.unity
+++ b/Path Creator Project/Assets/PathCreator/Examples/Scenes/GetClosestPointOnPath Test.unity
@@ -1,0 +1,438 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.44657844, g: 0.49641222, b: 0.57481694, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 11
+  m_GIWorkflowMode: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_TemporalCoherenceThreshold: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 1
+  m_LightmapEditorSettings:
+    serializedVersion: 10
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVRFilteringMode: 2
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ShowResolutionOverlay: 1
+  m_LightingDataAsset: {fileID: 0}
+  m_UseShadowmask: 1
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &184727957
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 184727959}
+  - component: {fileID: 184727958}
+  m_Layer: 0
+  m_Name: Path
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &184727958
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 184727957}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8e5ac92bc18f545cc84cd886ece82b4d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  editorData:
+    _bezierPath:
+      points:
+      - {x: -4.350084, y: -0.6192361, z: 0.36958665}
+      - {x: -4.3119984, y: -0.27224493, z: 2.7627096}
+      - {x: -2.500093, y: 1.7315861, z: 2.2386506}
+      - {x: 0.14839771, y: 1.7105651, z: 2.2219813}
+      - {x: 2.7968912, y: 1.6895441, z: 2.205312}
+      - {x: 4.16408, y: -0.44785511, z: 2.1293974}
+      - {x: 4.3446193, y: -0.6192361, z: 0.36958665}
+      - {x: 4.5251584, y: -0.7906171, z: -1.390224}
+      - {x: 3.2920637, y: 0.7694727, z: -2.9261537}
+      - {x: 0.77272415, y: 0.83640313, z: -3.0503848}
+      - {x: -1.7466154, y: 0.90333354, z: -3.1746159}
+      - {x: -4.3881693, y: -0.9662273, z: -2.0235362}
+      isClosed: 1
+      space: 0
+      controlMode: 1
+      autoControlLength: 0.3
+      boundsUpToDate: 0
+      bounds:
+        m_Center: {x: 0.005727291, y: 0.5250117, z: -0.39030027}
+        m_Extent: {x: 4.3562183, y: 1.1872373, z: 2.6691647}
+      perAnchorNormalsAngle:
+      - 0
+      - 0
+      - 0
+      - 0
+      globalNormalsAngle: 69
+      flipNormals: 0
+    vertexPathUpToDate: 1
+    vertexPathMaxAngleError: 0.3
+    vertexPathMinVertexSpacing: 0
+    showTransformTool: 1
+    showPathBounds: 0
+    showPerSegmentBounds: 0
+    displayAnchorPoints: 1
+    displayControlPoints: 1
+    bezierHandleScale: 1
+    globalDisplaySettingsFoldout: 0
+    keepConstantHandleSize: 0
+    showNormalsInVertexMode: 0
+    showBezierPathInVertexMode: 0
+    showDisplayOptions: 0
+    showPathOptions: 1
+    showVertexPathDisplayOptions: 0
+    showVertexPathOptions: 1
+    showNormals: 0
+    showNormalsHelpInfo: 0
+    tabIndex: 0
+  initialized: 1
+--- !u!4 &184727959
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 184727957}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1266884696
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4125965570099986, guid: 761d600d1e80341ac97f3228771ce637, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4125965570099986, guid: 761d600d1e80341ac97f3228771ce637, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4125965570099986, guid: 761d600d1e80341ac97f3228771ce637, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4125965570099986, guid: 761d600d1e80341ac97f3228771ce637, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4125965570099986, guid: 761d600d1e80341ac97f3228771ce637, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4125965570099986, guid: 761d600d1e80341ac97f3228771ce637, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4125965570099986, guid: 761d600d1e80341ac97f3228771ce637, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4125965570099986, guid: 761d600d1e80341ac97f3228771ce637, type: 2}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 114548013775708692, guid: 761d600d1e80341ac97f3228771ce637,
+        type: 2}
+      propertyPath: pathCreator
+      value: 
+      objectReference: {fileID: 184727958}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 761d600d1e80341ac97f3228771ce637, type: 2}
+  m_IsPrefabParent: 0
+--- !u!4 &1266884697 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 4125965570099986, guid: 761d600d1e80341ac97f3228771ce637,
+    type: 2}
+  m_PrefabInternal: {fileID: 1266884696}
+--- !u!1 &1308570505
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1308570508}
+  - component: {fileID: 1308570507}
+  - component: {fileID: 1308570506}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &1308570506
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1308570505}
+  m_Enabled: 1
+--- !u!20 &1308570507
+Camera:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1308570505}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1308570508
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1308570505}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1414926773
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1414926775}
+  - component: {fileID: 1414926774}
+  m_Layer: 0
+  m_Name: GetClosestPointOnPathTest
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1414926774
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1414926773}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2353903649ab3c34eb2a2bffc094de57, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  pathCreator: {fileID: 184727958}
+  objectOnPath: {fileID: 1266884697}
+--- !u!4 &1414926775
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1414926773}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.1773397, y: -2.0806398, z: -0.9905968}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1844901808
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1844901810}
+  - component: {fileID: 1844901809}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1844901809
+Light:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1844901808}
+  m_Enabled: 1
+  serializedVersion: 8
+  m_Type: 1
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_Lightmapping: 4
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &1844901810
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1844901808}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}

--- a/Path Creator Project/Assets/PathCreator/Examples/Scenes/GetClosestPointOnPath Test.unity.meta
+++ b/Path Creator Project/Assets/PathCreator/Examples/Scenes/GetClosestPointOnPath Test.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fbb1f45e5065be44badcc1594a52435a
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Path Creator Project/Assets/PathCreator/Examples/Scripts/GetClosestPointOnPathTest.cs
+++ b/Path Creator Project/Assets/PathCreator/Examples/Scripts/GetClosestPointOnPathTest.cs
@@ -1,26 +1,121 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
+using PathCreation;
+using PathCreation.Utility;
 
 namespace PathCreation.Examples
 {
 	public class GetClosestPointOnPathTest : MonoBehaviour
 	{
 		public PathCreator pathCreator;
-		public Transform objectOnPath;
+
+        public Transform inputPositionObject;
+        public Transform oldMethodObject;
+        public Transform newMethodObject;
 
 		void Update()
 		{
-			// Wait for the PathFollower Component to set objectOnPath on the path
-			if (Time.timeSinceLevelLoad < 0.1f)
-				return;
+            // Get a point around the path
+            Vector3 worldPoint = pathCreator.path.GetPointAtDistance(Time.time * 2) + new Vector3(Mathf.Sin(Time.time)*2, Mathf.Sin(1+Time.time*0.5f)*2.5f, Mathf.Sin(2+Time.time*0.3f)*3);
 
-			// Since objectOnPath travels on the path, the actualWorldPoint and closestPointOnPath
-			// should be pretty close to each other.
-			Vector3 actualWorldPoint = objectOnPath.position;
-			Vector3 closestPointOnPath = pathCreator.path.GetClosestPointOnPath(actualWorldPoint);
+            UnityEngine.Profiling.Profiler.BeginSample("Before Optimization");
+            Vector3 oldClosestPointOnPath = OldGetClosestPointOnPath(pathCreator.path, worldPoint);
+            float oldClosestTimeOnPath = OldGetClosestTimeOnPath(pathCreator.path, worldPoint);
+            float oldClosestDistanceAlongPath = OldGetClosestDistanceAlongPath(pathCreator.path, worldPoint);
+            UnityEngine.Profiling.Profiler.EndSample();
 
-			var distance = Vector3.Distance(actualWorldPoint, closestPointOnPath);
-			if (distance > 0.001f)
-				Debug.LogErrorFormat(this, "Points too far apart (distance={0})", distance);
-		}
-	}
+            UnityEngine.Profiling.Profiler.BeginSample("After Optimization");
+            Vector3 newClosestPointOnPath = pathCreator.path.GetClosestPointOnPath(worldPoint);
+            float newClosestTimeOnPath = pathCreator.path.GetClosestTimeOnPath(worldPoint);
+            float newClosestDistanceAlongPath = pathCreator.path.GetClosestDistanceAlongPath(worldPoint);
+            UnityEngine.Profiling.Profiler.EndSample();
+
+            // This much error we allow between the new and old implementations
+            float errorThreshold = 0.001f;
+
+            // Check if the GetClosestPointOnPath returned value is the same for the old and new implementation
+            if (Vector3.Distance(newClosestPointOnPath, oldClosestPointOnPath) > errorThreshold)
+                Debug.LogErrorFormat(this, "GetClosestPointOnPath() failed (distance={0})", Vector3.Distance(newClosestPointOnPath, oldClosestPointOnPath));
+
+            // Check if the GetClosestTimeOnPath returned value is the same for the old and new implementation
+            if (Mathf.Abs(newClosestTimeOnPath - oldClosestTimeOnPath) > errorThreshold)
+                Debug.LogErrorFormat(this, "GetClosestTimeOnPath() failed. new={0}, old={1}", newClosestTimeOnPath, oldClosestTimeOnPath);
+
+            // Check if the GetClosestDistanceAlongPath returned value is the same for the old and new implementation
+            if (Mathf.Abs(newClosestDistanceAlongPath - oldClosestDistanceAlongPath) > errorThreshold)
+                Debug.LogErrorFormat(this, "GetClosestDistanceAlongPath() failed. new={0}, old={1}", newClosestDistanceAlongPath, oldClosestDistanceAlongPath);
+
+            // Visualize the input position
+            inputPositionObject.position = worldPoint;
+
+            // Visualize the computed path position
+            oldMethodObject.position = oldClosestPointOnPath;
+            newMethodObject.position = newClosestPointOnPath;
+
+            // Draw lines to connect the input position and the calculated output positions
+            Debug.DrawLine(worldPoint, oldClosestPointOnPath, Color.red);
+            Debug.DrawLine(worldPoint, newClosestPointOnPath, Color.green);
+        }
+
+        // This is the old VertexPath code before the optimization. I copied it here to compare its
+        // results to the new implementation, to make sure it still returns the same values after the optimization.
+        Vector3 OldGetClosestPointOnPath(VertexPath path, Vector3 worldPoint)
+        {
+            VertexPath.TimeOnPathData data = OldCalculateClosestPointOnPathData(path, worldPoint);
+            return Vector3.Lerp(path.GetPoint(data.previousIndex), path.GetPoint(data.nextIndex), data.percentBetweenIndices);
+        }
+
+        float OldGetClosestTimeOnPath(VertexPath path, Vector3 worldPoint)
+        {
+            VertexPath.TimeOnPathData data = OldCalculateClosestPointOnPathData(path, worldPoint);
+            return Mathf.Lerp(path.times[data.previousIndex], path.times[data.nextIndex], data.percentBetweenIndices);
+        }
+
+        float OldGetClosestDistanceAlongPath(VertexPath path, Vector3 worldPoint)
+        {
+            VertexPath.TimeOnPathData data = OldCalculateClosestPointOnPathData(path, worldPoint);
+            return Mathf.Lerp(path.cumulativeLengthAtEachVertex[data.previousIndex], path.cumulativeLengthAtEachVertex[data.nextIndex], data.percentBetweenIndices);
+        }
+
+        VertexPath.TimeOnPathData OldCalculateClosestPointOnPathData(VertexPath path, Vector3 worldPoint)
+        {
+            Vector3[] localPoints = path.localNormals;
+            bool isClosedLoop = path.isClosedLoop;
+
+            float minSqrDst = float.MaxValue;
+            Vector3 closestPoint = Vector3.zero;
+            int closestSegmentIndexA = 0;
+            int closestSegmentIndexB = 0;
+
+            for (int i = 0; i < localPoints.Length; i++)
+            {
+                int nextI = i + 1;
+                if (nextI >= localPoints.Length)
+                {
+                    if (isClosedLoop)
+                    {
+                        nextI %= localPoints.Length;
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+
+                Vector3 closestPointOnSegment = MathUtility.ClosestPointOnLineSegment(worldPoint, path.GetPoint(i), path.GetPoint(nextI));
+                float sqrDst = (worldPoint - closestPointOnSegment).sqrMagnitude;
+                if (sqrDst < minSqrDst)
+                {
+                    minSqrDst = sqrDst;
+                    closestPoint = closestPointOnSegment;
+                    closestSegmentIndexA = i;
+                    closestSegmentIndexB = nextI;
+                }
+
+            }
+            float closestSegmentLength = (path.GetPoint(closestSegmentIndexA) - path.GetPoint(closestSegmentIndexB)).magnitude;
+            float t = (closestPoint - path.GetPoint(closestSegmentIndexA)).magnitude / closestSegmentLength;
+            return new VertexPath.TimeOnPathData(closestSegmentIndexA, closestSegmentIndexB, t);
+        }
+    }
 }

--- a/Path Creator Project/Assets/PathCreator/Examples/Scripts/GetClosestPointOnPathTest.cs
+++ b/Path Creator Project/Assets/PathCreator/Examples/Scripts/GetClosestPointOnPathTest.cs
@@ -1,0 +1,26 @@
+﻿using UnityEngine;
+
+namespace PathCreation.Examples
+{
+	public class GetClosestPointOnPathTest : MonoBehaviour
+	{
+		public PathCreator pathCreator;
+		public Transform objectOnPath;
+
+		void Update()
+		{
+			// Wait for the PathFollower Component to set objectOnPath on the path
+			if (Time.timeSinceLevelLoad < 0.1f)
+				return;
+
+			// Since objectOnPath travels on the path, the actualWorldPoint and closestPointOnPath
+			// should be pretty close to each other.
+			Vector3 actualWorldPoint = objectOnPath.position;
+			Vector3 closestPointOnPath = pathCreator.path.GetClosestPointOnPath(actualWorldPoint);
+
+			var distance = Vector3.Distance(actualWorldPoint, closestPointOnPath);
+			if (distance > 0.001f)
+				Debug.LogErrorFormat(this, "Points too far apart (distance={0})", distance);
+		}
+	}
+}

--- a/Path Creator Project/Assets/PathCreator/Examples/Scripts/GetClosestPointOnPathTest.cs.meta
+++ b/Path Creator Project/Assets/PathCreator/Examples/Scripts/GetClosestPointOnPathTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2353903649ab3c34eb2a2bffc094de57
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR contains an optimized version of VertexPath.CalculateClosestPointOnPathData, which positively affects the performance of:

- VertexPath.GetClosestPointOnPath
- VertexPath.GetClosestTimeOnPath
- VertexPath.GetClosestDistanceAlongPath

The idea of the optimization is to perform all the math and specifically "ClosestPointOnLineSegment" in local-space, because then there is no need to transform every point in the path to world-space.

This works by transforming the incoming "worldPoint" from world-space to "VertexPath local space" only once. The result CalculateClosestPointOnPathData result is then transformed from local-  to world-space again.

On my machine, profiling before and after the optimization shows:

- Old implementation: 5.58ms - 14.62ms
- New implementation: 0.25ms - 0.40ms

I've used the scene "GetClosestPointOnPath Test" to test and profile the new implementation against the old one.
