### PR TITLE
Fix NaN normals

### DIFF
--- a/Path Creator Project/Assets/PathCreator/Core/Runtime/Objects/VertexPath.cs
+++ b/Path Creator Project/Assets/PathCreator/Core/Runtime/Objects/VertexPath.cs
@@ -140,7 +140,7 @@ namespace PathCreation {
                     }
                     for (int i = 0; i < num; i++) {
                         int vertIndex = startVertIndex + i;
-                        float t = i / (num - 1f);
+                        float t = num == 1 ? 1f : i / (num - 1f);
                         float angle = startAngle + deltaAngle * t;
                         Quaternion rot = Quaternion.AngleAxis (angle, localTangents[vertIndex]);
                         localNormals[vertIndex] = (rot * localNormals[vertIndex]) * ((bezierPath.FlipNormals) ? -1 : 1);


### PR DESCRIPTION
I noticed when getting normals from a VertexPath object sometimes it would return a NaN vector.
The reason for this was that in the case "num" was 1 a division by 0 would occur. Hence the NaN.