### PR TITLE
Bug fix for "Constant Point Size" not working if PathCreator object isn't at World Zero.

### DIFF
--- a/Path Creator Project/Assets/PathCreator/Core/Editor/PathEditor.cs
+++ b/Path Creator Project/Assets/PathCreator/Core/Editor/PathEditor.cs
@@ -350,8 +350,8 @@ namespace PathCreationEditor {
             for (int i = 0; i < bezierPath.NumPoints; i += 3) {
 
                 int handleIndex = (previousMouseOverHandleIndex + i) % bezierPath.NumPoints;
-                float handleRadius = GetHandleDiameter (globalDisplaySettings.anchorSize * data.bezierHandleScale, bezierPath[handleIndex]) / 2f;
                 Vector3 pos = MathUtility.TransformPoint (bezierPath[handleIndex], creator.transform, bezierPath.Space);
+                float handleRadius = GetHandleDiameter (globalDisplaySettings.anchorSize * data.bezierHandleScale, pos) / 2f;
                 float dst = HandleUtility.DistanceToCircle (pos, handleRadius);
                 if (dst == 0) {
                     mouseOverHandleIndex = handleIndex;
@@ -510,8 +510,8 @@ namespace PathCreationEditor {
         void DrawHandle (int i) {
             Vector3 handlePosition = MathUtility.TransformPoint (bezierPath[i], creator.transform, bezierPath.Space);
 
-            float anchorHandleSize = GetHandleDiameter (globalDisplaySettings.anchorSize * data.bezierHandleScale, bezierPath[i]);
-            float controlHandleSize = GetHandleDiameter (globalDisplaySettings.controlSize * data.bezierHandleScale, bezierPath[i]);
+            float anchorHandleSize = GetHandleDiameter (globalDisplaySettings.anchorSize * data.bezierHandleScale, handlePosition);
+            float controlHandleSize = GetHandleDiameter (globalDisplaySettings.controlSize * data.bezierHandleScale, handlePosition);
 
             bool isAnchorPoint = i % 3 == 0;
             bool isInteractive = isAnchorPoint || bezierPath.ControlPointMode != BezierPath.ControlMode.Automatic;


### PR DESCRIPTION
In PathEditor.cs, the variables `handleRadius` in `ProcessBezierPathInput`, and `anchor/controlHandleSize` in `DrawHandle`, previously referenced the raw bezierPath position information based on which index was requested, rather than the transformed position--this is curious, considering the transform position is calculated after handleRadius and before anchor/controlHandleSize are set.

As a result, Constant Point Size failed to display correctly if the GameObject for PathCreator was ever anywhere but [0,0,0], causing strange deformations in the point's sizes when moving/rotating the camera. Viewable below.

https://user-images.githubusercontent.com/7088788/119603586-1e4b9e80-bdb3-11eb-92af-c5bc2a203bbf.mp4

From my testing, this doesn't seem to introduce any new issues, and as seen in the below video, the issue appears to be corrected.

https://user-images.githubusercontent.com/7088788/119603644-33c0c880-bdb3-11eb-821e-45b2fc5ade2f.mp4