### PR TITLE
Add path generation button to GeneratePathExample

### DIFF
--- a/Path Creator Project/Assets/PathCreator/Examples/Scripts/Editor/GeneratePathExampleEditor.cs
+++ b/Path Creator Project/Assets/PathCreator/Examples/Scripts/Editor/GeneratePathExampleEditor.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+using UnityEditor;
+using PathCreation;
+
+namespace PathCreation.Examples
+{
+    [CustomEditor(typeof(GeneratePathExample), true)]
+    public class GeneratePathExampleEditor : Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            DrawDefaultInspector();
+
+            GeneratePathExample generatePathExample = (GeneratePathExample) target;
+            if (GUILayout.Button("Generate Path"))
+            {
+                generatePathExample.GeneratePath();
+            }
+        }
+    }   
+}

--- a/Path Creator Project/Assets/PathCreator/Examples/Scripts/GeneratePathExample.cs
+++ b/Path Creator Project/Assets/PathCreator/Examples/Scripts/GeneratePathExample.cs
@@ -1,19 +1,20 @@
 ﻿using UnityEngine;
 
 namespace PathCreation.Examples {
-    // Example of creating a path at runtime from a set of points.
-
+    // Example of creating a path from a set of points upon button press in the editor.
     [RequireComponent(typeof(PathCreator))]
-    public class GeneratePathExample : MonoBehaviour {
-
+    public class GeneratePathExample : MonoBehaviour
+    {
         public bool closedLoop = true;
-        public Transform[] waypoints;
+        public Transform[] waypoints = new Transform[0];
 
-        void Start () {
-            if (waypoints.Length > 0) {
+        public void GeneratePath()
+        {
+            if (waypoints.Length > 0)
+            {
                 // Create a new bezier path from the waypoints.
-                BezierPath bezierPath = new BezierPath (waypoints, closedLoop, PathSpace.xyz);
-                GetComponent<PathCreator> ().bezierPath = bezierPath;
+                BezierPath bezierPath = new BezierPath(waypoints, closedLoop, PathSpace.xyz);
+                GetComponent<PathCreator>().bezierPath = bezierPath;
             }
         }
     }


### PR DESCRIPTION
Now, _PathCreator_ variables are **not reset on runtime** when using _GeneratePathExample_.

## Pre-commit
![editor](https://user-images.githubusercontent.com/31420614/147306078-6ec9f408-4f3c-4fc0-b2a1-7d4d09ec9bcc.PNG)  |  ![runtime](https://user-images.githubusercontent.com/31420614/147306087-6b024856-f1d3-4608-b862-3cd2da3a669e.PNG)
:-------------------------:|:-------------------------:
![beforeEditor](https://user-images.githubusercontent.com/31420614/147306076-748a23e3-2f2c-428a-b9e6-7463ca65ee0f.PNG)  |  ![runtimeEditor](https://user-images.githubusercontent.com/31420614/147306082-3118a7df-b3f5-440e-8322-99c6b539c635.PNG) &nbsp; values reset 👎.

## Post-commit
![editor](https://user-images.githubusercontent.com/31420614/147306078-6ec9f408-4f3c-4fc0-b2a1-7d4d09ec9bcc.PNG)  |  ![runtime](https://user-images.githubusercontent.com/31420614/147306087-6b024856-f1d3-4608-b862-3cd2da3a669e.PNG)
:-------------------------:|:-------------------------:
![fixedRuntimeEditor](https://user-images.githubusercontent.com/31420614/147306101-6dcdd125-d759-4907-8949-e62b943ea738.PNG)  |  ![fixedRuntimeEditor](https://user-images.githubusercontent.com/31420614/147306101-6dcdd125-d759-4907-8949-e62b943ea738.PNG) &nbsp; values retained 👍.